### PR TITLE
Fix Promote via BGDL

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(nopsmdrm
   SceIofilemgrForDriver_stub
   SceNpDrmForDriver_stub
   SceSysclibForDriver_stub
+  SceSysmemForDriver_stub
   SceThreadmgrForDriver_stub
   SceRegMgrForDriver_stub
   taihenForKernel_stub


### PR DESCRIPTION
I finally found why i wasn't able to install PSM Games via the background downloader!

it was the scePsmDrmGetRifNameForInstall, which takes a RIF as input and tries to verify its RSA signature. which fails always on FAKE.RIF,

the solution is to hook the scePsmDrmGetRifNameForInstall and always give the "FAKE.rif" ..

oh yeah, also i changed the names of a few of your patch functions as there are names for those functions in the vitasdk now.
